### PR TITLE
fix(ci): pr-build summarization step

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -160,6 +160,7 @@ jobs:
         id: summarize
         shell: bash
         run: |
+          set -x
           {
             echo "## Build Matrix Results"
             echo ""
@@ -167,6 +168,10 @@ jobs:
             echo "|-------------|--------------|---------|--------------|-----------------|------------|------------|"
           } > comment.md
           for f in ${{ steps.dl.outputs.download-path }}/*.json; do
+            echo "debug"
+            cat "$f"
+            echo "/debug"
+
             php=$(jq -r .php "$f")
             arch=$(jq -r .arch "$f")
             status=$(jq -r .status "$f")

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Upload build result
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: build-results-${{  steps.resultfile.outputs.filename }}
+          name: build-results-${{ steps.resultfile.outputs.filename }}
           path: results/
           overwrite: true
           if-no-files-found: warn
@@ -151,6 +151,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Download all build results
+        id: dl
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: results
@@ -165,7 +166,7 @@ jobs:
             echo "| PHP Version | Architecture | Status  | Duration (s) | Image Size (MB) | Base Image | Cache Used |"
             echo "|-------------|--------------|---------|--------------|-----------------|------------|------------|"
           } > comment.md
-          for f in results/*.json; do
+          for f in ${{ steps.dl.outputs.download-path }}/*.json; do
             php=$(jq -r .php "$f")
             arch=$(jq -r .arch "$f")
             status=$(jq -r .status "$f")

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -153,7 +153,6 @@ jobs:
       - name: Download all build results
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: build-results-*
           path: results
 
       - name: Summarize results

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -167,7 +167,7 @@ jobs:
             echo "| PHP Version | Architecture | Status  | Duration (s) | Image Size (MB) | Base Image | Cache Used |"
             echo "|-------------|--------------|---------|--------------|-----------------|------------|------------|"
           } > comment.md
-          for f in ${{ steps.dl.outputs.download-path }}/*.json; do
+          for f in ${{ steps.dl.outputs.download-path }}/**/*.json; do
             echo "debug"
             cat "$f"
             echo "/debug"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pr-build.yml` file. The change removes the `name` parameter from the `actions/download-artifact` step in the workflow.